### PR TITLE
Improve bubble style and info in tooltips

### DIFF
--- a/src/components/theme/datablocks/BubbleChart/bubble-chart.less
+++ b/src/components/theme/datablocks/BubbleChart/bubble-chart.less
@@ -19,6 +19,7 @@
       border-radius: 50%;
       will-change: left, top, height, width;
       font-weight: bold;
+      white-space: nowrap;
 
       &:hover {
         /* Show the overflow when hovering over a label */
@@ -32,11 +33,13 @@
       &::after {
         content: '';
         opacity: 0;
+        width: 0;
+
         margin: 0;
+        margin-top: 10%;
         background-color: currentColor;
         height: 1%;
         transition: opacity 0.4s, width 0.4s;
-        width: 0;
         box-sizing: border-box;
       }
 
@@ -47,19 +50,10 @@
         }
       }
       /* End: Styles for the underline animation */
+    }
 
-      /* Optional, but recommended - reduce the size of text on medium bubbles */
-      &.medium {
-        font-size: 0.8em;
-      }
-      /* Optional, but recommended - hide the text on small bubbles */
-      &.small {
-        font-size: 0;
-        /* Make sure to unhide the text when hovering */
-        &:hover {
-          font-size: 0.8em;
-        }
-      }
+    .tooltip {
+      white-space: break-spaces;
     }
   }
 }

--- a/src/components/theme/datablocks/BubbleChart/fitText/LICENSE
+++ b/src/components/theme/datablocks/BubbleChart/fitText/LICENSE
@@ -1,0 +1,21 @@
+ MIT License
+
+Copyright (c) 2018 Ricardo Gonçalves
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/components/theme/datablocks/BubbleChart/fitText/README.md
+++ b/src/components/theme/datablocks/BubbleChart/fitText/README.md
@@ -1,0 +1,3 @@
+# Credit
+
+Downloaded from https://github.com/ricardobrg/fitText and modified.

--- a/src/components/theme/datablocks/BubbleChart/fitText/fittext.js
+++ b/src/components/theme/datablocks/BubbleChart/fitText/fittext.js
@@ -1,0 +1,46 @@
+/**
+ * @param {string|HTMLElement} outputSelector
+ */
+export function fitText(outputSelector) {
+  // max font size in pixels
+  const maxFontSize = 100;
+
+  let outputDiv;
+  if (typeof outputSelector === 'string') {
+    // get the DOM output element by its selector
+    outputDiv = document.getElementById(outputSelector);
+  } else {
+    outputDiv = outputSelector;
+  }
+
+  // get element's width
+  let width = outputDiv.clientWidth;
+  // get content's width
+  let contentWidth = outputDiv.scrollWidth;
+  // get fontSize
+  let fontSize = parseInt(
+    window.getComputedStyle(outputDiv, null).getPropertyValue('font-size'),
+    10,
+  );
+  // if content's width is bigger than elements width - overflow
+  if (contentWidth > width) {
+    fontSize = Math.ceil((fontSize * width) / contentWidth, 10);
+    fontSize = fontSize > maxFontSize ? (fontSize = maxFontSize) : fontSize - 1;
+    outputDiv.style.fontSize = fontSize + 'px';
+  } else {
+    // content is smaller than width... let's resize in 1 px until it fits
+    while (contentWidth === width && fontSize < maxFontSize) {
+      fontSize = Math.ceil(fontSize) + 1;
+      fontSize = fontSize > maxFontSize ? (fontSize = maxFontSize) : fontSize;
+      outputDiv.style.fontSize = fontSize + 'px';
+      // update widths
+      width = outputDiv.clientWidth;
+      contentWidth = outputDiv.scrollWidth;
+      if (contentWidth > width) {
+        outputDiv.style.fontSize = fontSize - 1 + 'px';
+      }
+    }
+  }
+
+  outputDiv.style.fontSize = parseInt(outputDiv.style.fontSize) * 0.9 + 'px';
+}


### PR DESCRIPTION
Locally I also have this code to make the bubbles bigger but it is specific to the data file I worked with:

```js
const { data = {}, provider_data = {} } = props;
const { size_column, label_column, height } = data;
const oldPoints =
  size_column && label_column && provider_data
    ? provider_data[label_column]?.map((d, index) => ({
        _id: d,
        value: provider_data[size_column]?.[index],
        colorValue: provider_data[size_column]?.[index],
      }))
    : [];

const groups = groupBy(oldPoints, (x) => {
  return x._id;
});
const points = Object.keys(groups).map((x, i) => {
  const o = groups[x];
  let c = 0;
  let s = 0;
  o.forEach((y) => {
    s += parseFloat(y.value);
    c += parseFloat(y.colorValue);
  });
  // console.log(provider_data[size_column]);
  return {
    ...o[0],
    value: s.toFixed(2),
    colorValue: c.toString(),
  };
});
```