### PR TITLE
New field in MAES Viewer Edit: hover template

### DIFF
--- a/src/components/Blocks/MaesViewer/MaesViewerEdit.jsx
+++ b/src/components/Blocks/MaesViewer/MaesViewerEdit.jsx
@@ -20,6 +20,15 @@ class Edit extends Component {
 
     const newSchema = JSON.parse(JSON.stringify(schema));
     newSchema.properties.ecosystem.choices = choices;
+
+    if (this.props.data && !this.props.data.hoverTemplate) {
+      this.props.onChangeBlock(this.props.block, {
+        ...this.props.data,
+        hoverTemplate:
+          '%{customdata[0]}: %{customdata[2]:,.0f} Mm²<extra></extra>',
+      });
+    }
+
     return newSchema;
   };
 

--- a/src/components/Blocks/MaesViewer/MaesViewerView.jsx
+++ b/src/components/Blocks/MaesViewer/MaesViewerView.jsx
@@ -42,9 +42,14 @@ const View = ({ data, provider_data, id, ...rest }) => {
   const [multiCharts, setMultiCharts] = React.useState([]);
   React.useEffect(() => {
     if (provider_data) {
-      setMultiCharts(makeChartTiles(provider_data, focusOn, focusEcosystem));
+      const { hoverTemplate } = data;
+      setMultiCharts(
+        makeChartTiles(provider_data, focusOn, focusEcosystem, {
+          hoverTemplate,
+        }),
+      );
     }
-  }, [provider_data, focusOn, focusEcosystem]);
+  }, [provider_data, focusOn, focusEcosystem, data]);
 
   return (
     <div className={cx('block align', data.align)}>

--- a/src/components/Blocks/MaesViewer/schema.js
+++ b/src/components/Blocks/MaesViewer/schema.js
@@ -10,7 +10,7 @@ const MaesViewerSchema = {
     {
       id: 'source',
       title: 'Data source',
-      fields: ['provider_url', 'ecosystem'],
+      fields: ['provider_url', 'ecosystem', 'hoverTemplate'],
     },
   ],
 
@@ -30,6 +30,11 @@ const MaesViewerSchema = {
     ecosystem: {
       title: 'Ecosystem',
       choices: [],
+    },
+    hoverTemplate: {
+      title: 'Hover template',
+      defaultValue:
+        '%{customdata[0]}: %{customdata[2]:,.0f} Mm²<extra></extra>',
     },
   },
 

--- a/src/components/Blocks/MaesViewer/utils.js
+++ b/src/components/Blocks/MaesViewer/utils.js
@@ -88,7 +88,7 @@ export function mapToAllEU(provider_data, byLevel) {
   return { EUByLevel, EUByLevelPercents };
 }
 
-export function makeTrace(level, levelData, index, focusOn) {
+export function makeTrace(level, levelData, index, focusOn, { hoverTemplate }) {
   const data = [
     ...Object.entries(levelData).filter(([k, v]) => k !== focusOn),
     [focusOn, levelData[focusOn]],
@@ -100,7 +100,11 @@ export function makeTrace(level, levelData, index, focusOn) {
   y.fill(0);
   y[y.length - 1] = 0.25; // we "lift" this value to "highlight" it
 
-  const hovertext = [...data.map(([k, v]) => k)];
+  // first element: country name
+  // second element: square kilometers (km2)
+  // third element: square megameters (Mm2)
+  const hovertext = _.map(data, (x) => [x[0], x[1] / 100, x[1] / 10000]);
+
   const text = [
     ...data.slice(0, data.length - 1).map((_) => null),
     `<b>${focusOn}</b>`,
@@ -120,13 +124,16 @@ export function makeTrace(level, levelData, index, focusOn) {
       '#182844',
     ],
   };
+  const ht =
+    hoverTemplate ||
+    '%{customdata[0]}: %{customdata[2]:,.0f} Mm²<extra></extra>';
   const res = {
     x,
     y,
     // hovertext,
     // See
     // https://plotly.com/javascript/reference/scatter/#scatter-hovertemplate
-    hovertemplate: '%{customdata}: %{x:.2f}<extra></extra>',
+    hovertemplate: ht,
     hoverinfo: 'y',
     customdata: hovertext,
     name: level,
@@ -222,7 +229,12 @@ export function chartTileLayout(index, finalPercent) {
   };
 }
 
-export function makeChartTiles(provider_data, focusOn, focusEcosystem) {
+export function makeChartTiles(
+  provider_data,
+  focusOn,
+  focusEcosystem,
+  { hoverTemplate },
+) {
   if (!provider_data) return;
   const byLevel = mapByLevel(provider_data);
   const { EUByLevelPercents } = mapToAllEU(provider_data, byLevel);
@@ -247,7 +259,9 @@ export function makeChartTiles(provider_data, focusOn, focusEcosystem) {
       if (focusEcosystem && level !== focusEcosystem) return null;
       return {
         layout: chartTileLayout(index, EUByLevelPercents[level]),
-        data: [makeTrace(level, byArea[level], index, focusOn)],
+        data: [
+          makeTrace(level, byArea[level], index, focusOn, { hoverTemplate }),
+        ],
         title: level,
       };
     })


### PR DESCRIPTION
The new field is backward compatible (filled automatically on new edits with a good default value for the data set I had for testing).

The default value is:

```
%{customdata[0]}: %{customdata[2]:,.0f} Mm²<extra></extra>
```

![image](https://user-images.githubusercontent.com/198924/97706114-d2a37180-1abd-11eb-8b5e-fefeaa6a8771.png)

After a small change to that (added the `(testing)` string), it looks like this:

![image](https://user-images.githubusercontent.com/198924/97706267-1007ff00-1abe-11eb-9b42-dc1b1f87fc73.png)

Q1: Should there be a helpful description of this field?

Q2: Should we use a string replacement so that:?
1. `%{customdata[0]}` becomes `%{countryName}`
2. `%{customdata[1]}` becomes `%{km2}`
3. `%{customdata[2]}` becomes `%{mm2}`