### PR TITLE
Solve: first selecting a country in MAES Viewer

### DIFF
--- a/src/components/Blocks/MaesViewer/MaesViewerView.jsx
+++ b/src/components/Blocks/MaesViewer/MaesViewerView.jsx
@@ -41,16 +41,31 @@ const View = ({ data, provider_data, id, ...rest }) => {
   const focusEcosystem = data.ecosystem;
   const [focusOn, setFocusOn] = React.useState();
   const [multiCharts, setMultiCharts] = React.useState([]);
+  const [firstRender, setFirstRender] = React.useState(true);
   React.useEffect(() => {
     if (provider_data) {
       const { hoverTemplate } = data;
-      setMultiCharts(
-        makeChartTiles(provider_data, focusOn, focusEcosystem, {
-          hoverTemplate,
-        }),
-      );
+      const ct = makeChartTiles(provider_data, focusOn, focusEcosystem, {
+        hoverTemplate,
+      });
+      setMultiCharts(ct);
+
+      // TODO: avoid this hack:
+      // hack to make the first-in-time selected country's label appear above
+      // the blue disc in the View of the MAES Viewer block
+      // (to make sure the hack is not needed anymore, remove this piece of code
+      // and if in the View of the page with the MAES Viewer's block the View of
+      // the MAES Viewer does not show the text above the black disc when first
+      // selecting a country in the CountrySelect, the hack is still needed
+      // because plotly.js or react-plotly.js puts the label of the black disc
+      // asynchronously and I think there is no Promise to depend on it)
+      if (firstRender) {
+        setTimeout(() => {
+          setFirstRender(false);
+        }, 2000);
+      }
     }
-  }, [provider_data, focusOn, focusEcosystem, data]);
+  }, [provider_data, focusOn, focusEcosystem, data, firstRender]);
 
   return (
     <div className={cx('block align', data.align)}>


### PR DESCRIPTION
does not show the label over the black discs that appear in the charts.

There also seems to be a new issue: in the editor of the MAES Viewer block, opening the CountrySelect using click automatically closes it after a few fractions of second. I am not able to select something on its first opening. The second click opens it well and I can use it well then. @tiberiuichim If you want I can open a separate issue for this.