### PR TITLE
Remove the 5 blocks added from volto-datablocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,12 @@ export default (config) => {
     },
   ];
 
+  delete config.blocks.blocksConfig.data_connected_block;
+  delete config.blocks.blocksConfig.auto_select_parameter;
+  delete config.blocks.blocksConfig.discodata_connector_block;
+  delete config.blocks.blocksConfig.discodata_sql_builder;
+  delete config.blocks.blocksConfig.discodata_table_block;
+
   return [
     installDataCatalogue,
     installKeyFacts,


### PR DESCRIPTION
~~**Remains to be done:**~~ DONE (https://github.com/eea/volto-bise/pull/40): only remove the blocks that are added with the volto-datablocks installation method used in BISE frontend. (The changes done till now are based on a modified version of the package.json file.)